### PR TITLE
Add explicit page title

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
 
     <link rel="icon" href="/assets/brainimage.jpg" type="image/jpeg">
 
+    <title>Debugging Your Brain</title>
+
     <meta property='og:title' content='Debugging Your Brain' />
     <meta property='og:image' content='https://www.debuggingyourbrain.com/DYBCoverRGB@2x.jpg' />
     <meta property='og:description'


### PR DESCRIPTION
Firefox isn't grabbing the title from the meta tag so it's just showing the URL - figured this would clear that up. Hope this helps (and congrats!)!